### PR TITLE
BUGFIX - Resize function calling correct parent function

### DIFF
--- a/MagentoCatalog/Model/Product/Image.php
+++ b/MagentoCatalog/Model/Product/Image.php
@@ -44,6 +44,6 @@ class Image extends \Magento\Catalog\Model\Product\Image
     	if($this->isEnvironmentMdoq()){
     		return $this;
     	}
-    	return parent::saveFile();
+	return parent::resize();
     }
 }


### PR DESCRIPTION
we have been debugging an issue where, after deleting pub/media/catalog/product/cache and visiting a category page, the images were not being resized to the correct dimensions (view.xml).
Taking a look at the extension, the resize function is not calling the correct parent function: 

https://github.com/zero1limited/magento2-Mdoq-Connector/blob/c6109340040ba337050198f1237904fd2e7b6b8b/MagentoCatalog/Model/Product/Image.php#L42-L48

